### PR TITLE
Add new GET endpoint for '/123' to return a simple message

### DIFF
--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -15,6 +15,10 @@ app.get('/test123', (_req: Request, res: Response) => {
   res.send('This is GET method')
 })
 
+app.get('/123', (_req: Request, res: Response) => {
+  res.send('This is GET method')
+})
+
 app.listen(port, () => {
   console.log(`Server running at http://localhost:${port}`)
 })


### PR DESCRIPTION
## Pull Request: Add GET Endpoint and Remove Frontend Setup

**Brief Description:**

This pull request introduces a new GET endpoint `/123` on the backend and removes the initial frontend setup files.

**Detailed Description:**

*   **Backend:** A new GET endpoint `/123` has been added to `src/server.ts`. This endpoint currently returns a simple "This is GET method" message. This addition serves as a basic demonstration of endpoint functionality.

*   **Frontend:** The initial frontend setup generated by `create-next-app` has been removed. This includes the `.gitignore`, `README.md`, `eslint.config.mjs`, `next.config.ts`, `package-lock.json`, `package.json`, `postcss.config.js`, `tailwind.config.ts`, `tsconfig.json`, `app` directory, and `public` directory. Removing these files clears the way for a new frontend implementation.
