### PR TITLE
feat: add publicId to cosmetic creation and response, update validati…

### DIFF
--- a/Backend/src/controllers/cosmeticController.ts
+++ b/Backend/src/controllers/cosmeticController.ts
@@ -16,6 +16,7 @@ interface CreateCosmeticRequest {
   isNew?: boolean
   isSaleOff?: boolean
   image: string
+  publicId: string
 }
 
 interface CreateCosmeticResponse {
@@ -44,12 +45,13 @@ const createNew = async (
   next: NextFunction
 ): Promise<void> => {
   try {
-    if (!req.file || !req.file.path) {
+    if (!req.file) {
       throw new ApiError(StatusCodes.BAD_REQUEST, 'Image is required')
     }
     const reqBodyWithImage: CreateCosmeticRequest = {
       ...req.body,
-      image: req.file.path
+      image: req.file.path,
+      publicId: req.file.filename
     }
     req.body = reqBodyWithImage as CreateCosmeticRequest
     const result = await services.cosmeticService.createNew(req)

--- a/Backend/src/models/cosmeticModel.ts
+++ b/Backend/src/models/cosmeticModel.ts
@@ -52,6 +52,7 @@ const COSMETIC_COLLECTION_SCHEMA: Joi.ObjectSchema = Joi.object({
   isNew: Joi.boolean().default(true),
   isSaleOff: Joi.boolean().default(false),
   image: Joi.string().uri().required(),
+  publicId: Joi.string().required(),
   createdAt: Joi.date().timestamp('javascript').default(Date.now),
   updatedAt: Joi.date().timestamp('javascript').default(null),
   _destroy: Joi.boolean().default(false)

--- a/Backend/src/services/cosmeticService.ts
+++ b/Backend/src/services/cosmeticService.ts
@@ -16,6 +16,10 @@ interface ICosmeticResponse {
   originalPrice: number
   discountPrice: number
   image: string
+  publicId: string
+  rating: number
+  isNew: boolean
+  isSaleOff: boolean
   createdAt: Date
 }
 

--- a/Backend/src/utils/fomatter.ts
+++ b/Backend/src/utils/fomatter.ts
@@ -25,6 +25,7 @@ export const pickCosmetic = (cosmetic: any): any => {
     'isNew',
     'isSaleOff',
     'image',
+    'publicId',
     'createdAt',
     'updatedAt'
   ])


### PR DESCRIPTION
**Title:** Feat: Add publicId to Cosmetic Creation and Response

**Brief Description:** This pull request introduces the `publicId` field to cosmetic entities, enhancing image management capabilities.

**Detailed Description:**

This pull request includes the following changes:

-   **Backend:**
    -   **Cosmetic Creation:** Added `publicId` to the cosmetic creation request and response. This field stores the identifier of the image in the storage service (e.g., Cloudinary), facilitating easier image management and deletion.
    -   **Validation Schema:** Updated the cosmetic model validation schema (`COSMETIC_COLLECTION_SCHEMA`) to include the `publicId` field, ensuring it's a required string.
    -   **Utility Functions:** Modified utility functions (e.g., `pickCosmetic`) to include `publicId` in the extracted data.
    -   **Cosmetic Controller:** Updated to receive and pass the image public ID during cosmetic creation.
    -   **Cosmetic Service:** Updated the interface to accommodate the `publicId` field.

These changes allow the backend to properly manage and track images associated with cosmetic products, improving overall application functionality and maintainability.
